### PR TITLE
Add CtaButton component and render in hero

### DIFF
--- a/src/components/CtaButton.js
+++ b/src/components/CtaButton.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { BiEnvelope } from "react-icons/bi";
+
+const CtaButton = () => {
+  return (
+    <button className="btn-primary flex items-center ml-auto" type="button">
+          <BiEnvelope /> Contact
+    </button>
+  )
+}
+
+export default CtaButton

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { BiEnvelope } from "react-icons/bi";
 import { useState } from "react";
+import CtaButton from "./CtaButton";
 // import { IoMdMenu } from "react-icons/io";
 
 export default function Navbar() {
@@ -33,9 +34,7 @@ export default function Navbar() {
           <a href="A" className=" text-gray-800 hover:text-primary">
             Services
           </a>
-          <button className="btn-primary flex items-center" type="button">
-            <BiEnvelope /> Contact
-          </button>
+          <CtaButton/>
         </div>
 
         {/* Hamburger button */}
@@ -98,9 +97,7 @@ export default function Navbar() {
         >
           Services
         </a>
-        <button className="btn-primary flex items-center ml-auto" type="button">
-          <BiEnvelope /> Contact
-        </button>
+        <CtaButton/>
       </div>
     </nav>
   );

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -34,7 +34,9 @@ export default function Navbar() {
           <a href="A" className=" text-gray-800 hover:text-primary">
             Services
           </a>
-          <CtaButton/>
+          <a href="A" className=" text-gray-800 hover:text-primary">
+            Contact
+          </a>
         </div>
 
         {/* Hamburger button */}
@@ -97,7 +99,9 @@ export default function Navbar() {
         >
           Services
         </a>
-        <CtaButton/>
+        <a href="A" className=" text-gray-800 hover:text-primary">
+            Contact
+        </a>
       </div>
     </nav>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 
 /*Common stylings*/
 .btn-primary {
-  @apply bg-primary flex items-center gap-2 text-white font-bold uppercase px-4 py-2 rounded-full shadow outline-none  hover:shadow-lg hover:bg-secondary focus:outline-none ease-linear transition-all duration-150 focus:ring-4 focus:ring-inset focus:ring-gray-600;
+  @apply bg-primary flex items-center gap-2 text-white font-bold uppercase ml-0 px-4 py-2 rounded-full shadow outline-none  hover:shadow-lg hover:bg-secondary focus:outline-none ease-linear transition-all duration-150 focus:ring-4 focus:ring-inset focus:ring-gray-600;
 }
 
 .btn-secondary {

--- a/src/pages/home/Hero.js
+++ b/src/pages/home/Hero.js
@@ -12,12 +12,11 @@ const Hero = () => {
     <header className="header container mx-auto items-center flex h-screen max-h-860-px relative">
       <div className="md:pr-8">
         <h2 className="font-semibold text-6xl text-gray-800">
-          Custom web solutions designed just for you
+        We'll bring your online vision to life.
         </h2>
         <p className="mt-8 text-xl leading-relaxed text-gray-600">
           From concept to care, we build and maintain custom websites and
-          full-stack applications specialized in React and Ruby on Rails. We'll
-          bring your online vision to life and keep it running smoothly.
+          full-stack applications.
         </p>
       </div>
 

--- a/src/pages/home/Hero.js
+++ b/src/pages/home/Hero.js
@@ -1,6 +1,7 @@
 import React from "react";
 import placeholder from "../../assets/mrJam.png";
 import useIntersectionObserver from "../../hooks/useIntersectionObserver";
+import CtaButton from "../../components/CtaButton";
 
 const Hero = () => {
   const ref = useIntersectionObserver({
@@ -15,9 +16,12 @@ const Hero = () => {
         We'll bring your online vision to life.
         </h2>
         <p className="mt-8 text-xl leading-relaxed text-gray-600">
-          From concept to care, we build and maintain custom websites and
-          full-stack applications.
+          We specialize in building and maintaining websites and full-stack applications in React 
+          and Ruby on Rails. Contact us now to learn more about how we can help you.
         </p>
+        <div className="mt-6 flex justify-start">
+          <CtaButton/>
+        </div>
       </div>
 
       <img


### PR DESCRIPTION
This PR refactors the ctabutton into its own component and adds it to the hero. The navbar (habmburger and navbar) were updated to use this new component instead. I also noticed the button would apply margin left automatically when used in the hero, preventing aligning left, so had to add `ml-0` to the primary button css class. 

screenshot
![image](https://github.com/amirobinsonmuto/jam-landing-page/assets/95949082/2ee3f932-94f8-4817-82a1-f0dace447cc2)
