### PR TITLE
Contact form links

### DIFF
--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { BiEnvelope } from "react-icons/bi";
 
-const CtaButton = () => {
+const Contact = ({className, showEnvelope}) => {
+
   const scrollToContactForm = () => {
     const contactFormElement = document.getElementById('contact-form');
     if (contactFormElement) {
@@ -14,14 +15,13 @@ const CtaButton = () => {
   };
 
   return (
-    <button 
-      className="btn-primary flex items-center ml-auto" 
-      type="button"
+    <div
       onClick={scrollToContactForm}
+      className={className}
     >
-      <BiEnvelope /> Contact
-    </button>
+      {showEnvelope && <BiEnvelope/>} Contact
+    </div>
   );
 };
 
-export default CtaButton
+export default Contact

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -15,12 +15,12 @@ const Contact = ({className, showEnvelope}) => {
   };
 
   return (
-    <div
+    <button
       onClick={scrollToContactForm}
       className={className}
     >
       {showEnvelope && <BiEnvelope/>} Contact
-    </div>
+    </button>
   );
 };
 

--- a/src/components/CtaButton.js
+++ b/src/components/CtaButton.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { BiEnvelope } from "react-icons/bi";
+
+const CtaButton = () => {
+  return (
+    <button className="btn-primary flex items-center ml-auto" type="button">
+          <BiEnvelope /> Contact
+    </button>
+  )
+}
+
+export default CtaButton

--- a/src/components/CtaButton.js
+++ b/src/components/CtaButton.js
@@ -2,11 +2,26 @@ import React from 'react'
 import { BiEnvelope } from "react-icons/bi";
 
 const CtaButton = () => {
+  const scrollToContactForm = () => {
+    const contactFormElement = document.getElementById('contact-form');
+    if (contactFormElement) {
+      const { top } = contactFormElement.getBoundingClientRect();
+      window.scrollTo({
+        top: window.pageYOffset + top,
+        behavior: 'smooth',
+      });
+    }
+  };
+
   return (
-    <button className="btn-primary flex items-center ml-auto" type="button">
-          <BiEnvelope /> Contact
+    <button 
+      className="btn-primary flex items-center ml-auto" 
+      type="button"
+      onClick={scrollToContactForm}
+    >
+      <BiEnvelope /> Contact
     </button>
-  )
-}
+  );
+};
 
 export default CtaButton

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -37,7 +37,7 @@ const Footer = () => {
               Contact us today to start chatting!
             </h3>
             <div className="mb-4 mt-6">
-              <label className="sr-only">
+              <label className="sr-only" htmlFor="name">
                 Name
               </label>
               <input
@@ -49,7 +49,7 @@ const Footer = () => {
               />
             </div>
             <div className="mb-4">
-              <label className="sr-only">
+              <label className="sr-only" htmlFor="email">
                 Email
               </label>
               <input
@@ -61,7 +61,7 @@ const Footer = () => {
               />
             </div>
             <div className="mb-4">
-              <label className="sr-only">
+              <label className="sr-only" htmlFor="message">
                 Message
               </label>
               <textarea

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -30,13 +30,14 @@ const Footer = () => {
         <div
           ref={ref}
           className="animation-hidden flex justify-center bg-secondary shadow-xl rounded-lg -mt-64 py-16 px-12 relative z-10"
+          id="contact-form"
         >
           <form className="w-full text-center lg:w-8/12">
-            <h3g className="font-semibold text-3xl text-white">
+            <h3 className="font-semibold text-3xl text-white">
               Contact us today to start chatting!
-            </h3g>
+            </h3>
             <div className="mb-4 mt-6">
-              <label className="sr-only" for="name">
+              <label className="sr-only">
                 Name
               </label>
               <input
@@ -48,7 +49,7 @@ const Footer = () => {
               />
             </div>
             <div className="mb-4">
-              <label className="sr-only" for="email">
+              <label className="sr-only">
                 Email
               </label>
               <input
@@ -60,7 +61,7 @@ const Footer = () => {
               />
             </div>
             <div className="mb-4">
-              <label className="sr-only" for="message">
+              <label className="sr-only">
                 Message
               </label>
               <textarea

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,7 +1,6 @@
 import React from "react";
-import { BiEnvelope } from "react-icons/bi";
 import { useState } from "react";
-import CtaButton from "./CtaButton";
+import Contact from "./Contact";
 // import { IoMdMenu } from "react-icons/io";
 
 export default function Navbar() {
@@ -12,17 +11,6 @@ export default function Navbar() {
       setIsOpen(true);
     } else {
       setIsOpen(false);
-    }
-  };
-
-  const scrollToContactForm = () => {
-    const contactFormElement = document.getElementById('contact-form');
-    if (contactFormElement) {
-      const { top } = contactFormElement.getBoundingClientRect();
-      window.scrollTo({
-        top: window.pageYOffset + top,
-        behavior: 'smooth',
-      });
     }
   };
 
@@ -45,12 +33,7 @@ export default function Navbar() {
           <a href="A" className=" text-gray-800 hover:text-primary">
             Services
           </a>
-          <a 
-            className="text-gray-800 hover:text-primary"
-            onClick={scrollToContactForm}  
-          >
-            Contact
-          </a>
+          <Contact className="cursor-pointer" showEnvelope={false}/>
         </div>
 
         {/* Hamburger button */}

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -33,7 +33,7 @@ export default function Navbar() {
           <a href="A" className=" text-gray-800 hover:text-primary">
             Services
           </a>
-          <Contact className="cursor-pointer" showEnvelope={false}/>
+          <Contact className="text-gray-800 hover:text-primary" showEnvelope={false}/>
         </div>
 
         {/* Hamburger button */}
@@ -80,25 +80,23 @@ export default function Navbar() {
       {/* mobile menu */}
       <div
         className={` 
-        absolute md:hidden top-15 right-0 w-40 bg-gray-800 bg-opacity-90 transition-transform duration-300 ease-in-out transform-gpu p-4 ${
+        absolute md:hidden top-15 right-0 w-40 bg-gray-800 bg-opacity-90 transition-transform duration-300 ease-in-out transform-gpu p-4 rounded-md flex flex-col items-end ${
           isOpen ? "mobile-menu-open" : "mobile-menu-closed"
         }`}
       >
         <a
           href="a"
-          className="block text-white hover:text-primary mb-2 text-right mr-1"
+          className="block text-white hover:text-primary mb-2 mr-1"
         >
           About Us
         </a>
         <a
           href="a"
-          className="block text-white hover:text-primary mb-2 text-right mr-1"
+          className="block text-white hover:text-primary mb-2 mr-1"
         >
           Services
         </a>
-        <a href="A" className=" text-gray-800 hover:text-primary">
-            Contact
-        </a>
+        <Contact className="block text-white hover:text-primary" showEnvelope={false}/>
       </div>
     </nav>
   );

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -47,14 +47,14 @@ export default function Navbar() {
           onClick={handleClick}
         >
           <svg
-            class="hamburger fill-primary"
+            className="hamburger fill-primary"
             viewBox="0 0 100 100"
             width="50"
             height="50"
             transform="scale(0.8)"
           >
             <rect
-              class="line top"
+              className="line top"
               width="80"
               height="10"
               x="10"
@@ -62,7 +62,7 @@ export default function Navbar() {
               rx="5"
             ></rect>
             <rect
-              class="line middle"
+              className="line middle"
               width="80"
               height="10"
               x="10"
@@ -70,7 +70,7 @@ export default function Navbar() {
               rx="5"
             ></rect>
             <rect
-              class="line bottom"
+              className="line bottom"
               width="80"
               height="10"
               x="10"

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { BiEnvelope } from "react-icons/bi";
 import { useState } from "react";
+import CtaButton from "./CtaButton";
 // import { IoMdMenu } from "react-icons/io";
 
 export default function Navbar() {
@@ -33,9 +34,7 @@ export default function Navbar() {
           <a href="A" className=" text-gray-800 hover:text-primary">
             Services
           </a>
-          <button className="btn-primary flex items-center" type="button">
-            <BiEnvelope /> Contact
-          </button>
+          <CtaButton/>
         </div>
 
         {/* Hamburger button */}
@@ -98,9 +97,7 @@ export default function Navbar() {
         >
           Services
         </a>
-        <button className="btn-primary flex items-center ml-auto" type="button">
-          <BiEnvelope /> Contact
-        </button>
+        <CtaButton/>
       </div>
     </nav>
   );

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -86,13 +86,13 @@ export default function Navbar() {
       >
         <a
           href="a"
-          className="block text-white hover:text-primary mb-2 mr-1"
+          className="block text-white hover:text-primary mb-2"
         >
           About Us
         </a>
         <a
           href="a"
-          className="block text-white hover:text-primary mb-2 mr-1"
+          className="block text-white hover:text-primary mb-2"
         >
           Services
         </a>

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -15,6 +15,17 @@ export default function Navbar() {
     }
   };
 
+  const scrollToContactForm = () => {
+    const contactFormElement = document.getElementById('contact-form');
+    if (contactFormElement) {
+      const { top } = contactFormElement.getBoundingClientRect();
+      window.scrollTo({
+        top: window.pageYOffset + top,
+        behavior: 'smooth',
+      });
+    }
+  };
+
   return (
     <nav className="top-0 fixed w-full py-3 bg-white shadow z-50">
       <div className="container mx-auto flex items-center justify-between">
@@ -34,7 +45,10 @@ export default function Navbar() {
           <a href="A" className=" text-gray-800 hover:text-primary">
             Services
           </a>
-          <a href="A" className=" text-gray-800 hover:text-primary">
+          <a 
+            className="text-gray-800 hover:text-primary"
+            onClick={scrollToContactForm}  
+          >
             Contact
           </a>
         </div>

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -34,7 +34,9 @@ export default function Navbar() {
           <a href="A" className=" text-gray-800 hover:text-primary">
             Services
           </a>
-          <CtaButton/>
+          <a href="A" className=" text-gray-800 hover:text-primary">
+            Contact
+          </a>
         </div>
 
         {/* Hamburger button */}
@@ -97,7 +99,9 @@ export default function Navbar() {
         >
           Services
         </a>
-        <CtaButton/>
+        <a href="A" className=" text-gray-800 hover:text-primary">
+            Contact
+        </a>
       </div>
     </nav>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,10 @@
   }
 }
 
+.cursor-pointer {
+  cursor: pointer;
+}
+
 /*Hamburger Menu*/
 .hamburger {
   --button-color: #333;

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 
 /*Common stylings*/
 .btn-primary {
-  @apply bg-primary flex items-center gap-2 text-white font-bold uppercase px-4 py-2 rounded-full shadow outline-none  hover:shadow-lg hover:bg-secondary focus:outline-none ease-linear transition-all duration-150 focus:ring-4 focus:ring-inset focus:ring-gray-600;
+  @apply bg-primary flex items-center gap-2 text-white font-bold uppercase ml-0 px-4 py-2 rounded-full shadow outline-none  hover:shadow-lg hover:bg-secondary focus:outline-none ease-linear transition-all duration-150 focus:ring-4 focus:ring-inset focus:ring-gray-600;
 }
 
 .btn-secondary {

--- a/src/index.css
+++ b/src/index.css
@@ -35,10 +35,6 @@
   }
 }
 
-.cursor-pointer {
-  cursor: pointer;
-}
-
 /*Hamburger Menu*/
 .hamburger {
   --button-color: #333;

--- a/src/pages/home/Hero.js
+++ b/src/pages/home/Hero.js
@@ -12,12 +12,11 @@ const Hero = () => {
     <header className="header container mx-auto items-center flex h-screen max-h-860-px relative">
       <div className="md:pr-8">
         <h2 className="font-semibold text-6xl text-gray-800">
-          Custom web solutions designed just for you
+        We'll bring your online vision to life.
         </h2>
         <p className="mt-8 text-xl leading-relaxed text-gray-600">
           From concept to care, we build and maintain custom websites and
-          full-stack applications specialized in React and Ruby on Rails. We'll
-          bring your online vision to life and keep it running smoothly.
+          full-stack applications.
         </p>
       </div>
 

--- a/src/pages/home/Hero.js
+++ b/src/pages/home/Hero.js
@@ -21,7 +21,7 @@ const Hero = () => {
         </p>
         <div className="mt-6 flex justify-start">
           <Contact 
-            className="btn-primary flex items-center ml-auto cursor-pointer" 
+            className="btn-primary flex items-center ml-auto" 
             showEnvelope={true}
           />
         </div>

--- a/src/pages/home/Hero.js
+++ b/src/pages/home/Hero.js
@@ -1,7 +1,7 @@
 import React from "react";
 import placeholder from "../../assets/mrJam.png";
 import useIntersectionObserver from "../../hooks/useIntersectionObserver";
-import CtaButton from "../../components/CtaButton";
+import Contact from "../../components/Contact";
 
 const Hero = () => {
   const ref = useIntersectionObserver({
@@ -20,7 +20,10 @@ const Hero = () => {
           and Ruby on Rails. Contact us now to learn more about how we can help you.
         </p>
         <div className="mt-6 flex justify-start">
-          <CtaButton />
+          <Contact 
+            className="btn-primary flex items-center ml-auto cursor-pointer" 
+            showEnvelope={true}
+          />
         </div>
       </div>
 

--- a/src/pages/home/Hero.js
+++ b/src/pages/home/Hero.js
@@ -13,14 +13,14 @@ const Hero = () => {
     <header className="header container mx-auto items-center flex h-screen max-h-860-px relative">
       <div className="md:pr-8">
         <h2 className="font-semibold text-6xl text-gray-800">
-        We'll bring your online vision to life.
+          We'll bring your online vision to life.
         </h2>
         <p className="mt-8 text-xl leading-relaxed text-gray-600">
           We specialize in building and maintaining websites and full-stack applications in React 
           and Ruby on Rails. Contact us now to learn more about how we can help you.
         </p>
         <div className="mt-6 flex justify-start">
-          <CtaButton/>
+          <CtaButton />
         </div>
       </div>
 

--- a/src/pages/home/Hero.js
+++ b/src/pages/home/Hero.js
@@ -1,6 +1,7 @@
 import React from "react";
 import placeholder from "../../assets/mrJam.png";
 import useIntersectionObserver from "../../hooks/useIntersectionObserver";
+import CtaButton from "../../components/CtaButton";
 
 const Hero = () => {
   const ref = useIntersectionObserver({
@@ -15,9 +16,12 @@ const Hero = () => {
         We'll bring your online vision to life.
         </h2>
         <p className="mt-8 text-xl leading-relaxed text-gray-600">
-          From concept to care, we build and maintain custom websites and
-          full-stack applications.
+          We specialize in building and maintaining websites and full-stack applications in React 
+          and Ruby on Rails. Contact us now to learn more about how we can help you.
         </p>
+        <div className="mt-6 flex justify-start">
+          <CtaButton/>
+        </div>
       </div>
 
       <img


### PR DESCRIPTION
This PR adds a single `contact` component to use in the hero CTA button and navbar link for contact. It has a JS function to scroll down to the contact form when clicked and accepts classes and a boolean as props to set the classes and whether or not the envelope icon shows, respectively. This will work fine as long as the contact form remains in the footer i.e. always on the page.

It also addresses some syntax errors that were causing console errors in browser.

hamburger formatted and radius corners:
![image](https://github.com/amirobinsonmuto/jam-landing-page/assets/95949082/1204a058-4a79-438f-93ff-19fa56c87254)

